### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!,except: [:index, :show]
-  before_action :set_post, only: [:show, :edit, :update]
+  before_action :set_post, only: [:show, :edit, :update, :destroy]
   before_action :correct_user,only: [:edit, :update]
   def index
     @posts = Post.all.order("created_at DESC")
@@ -32,6 +32,11 @@ def update
   else
     render :edit, status: :unprocessable_entity
   end
+end
+
+def destroy
+  @post.destroy
+  redirect_to root_path
 end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!,except: [:index, :show]
   before_action :set_post, only: [:show, :edit, :update, :destroy]
-  before_action :correct_user,only: [:edit, :update]
+  before_action :correct_user,only: [:edit, :update, :destroy]
   def index
     @posts = Post.all.order("created_at DESC")
   end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,7 +27,7 @@
     <% if current_user == @post.user %>
     <%= link_to "商品の編集", edit_post_path(@post), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", post_path(@post), data: {turbo_method: :delete}, class:"item-destroy" %>
 
 <% else %> 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
-  resources :posts, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :posts
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "posts#index"
-  resources :posts, only: [:index, :new, :create, :show, :edit, :update]
+  resources :posts, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# What 
商品削除機能の実装

# Why
フリマアプリ完成のため


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://i.gyazo.com/f0891d7e0609ddbfc4c630c9b594d6f9.gif